### PR TITLE
Update lightCustom.scss - minitab responsive tables

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -215,6 +215,10 @@ $table-cell-padding-x-sm:     .45rem;
     table-layout: auto !important;
     width: auto !important;
     font-size: 0.875em !important;
+    display: block !important; /*need to make the table responsive*/
+    overflow-x: auto !important; /*need to make the table responsive*/
+    white-space: nowrap !important; /*need to make the table responsive*/
+    max-width: 100% !important; /*need to make the table responsive*/
   }
   table colgroup {
     border-top: none !important;


### PR DESCRIPTION
add options to .table in the minitab section to make them create a scroll bar when they overflow the window